### PR TITLE
Move pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 ## Proposed changes
-A clear and concise description of what your changes are. Explain to maintainers why we should accept your solution. Be sure to adhere to our [contribution guidelines](../../CONTRIBUTING.md) and tag your pull request appropriately.
+A clear and concise description of what your changes are. Explain to maintainers why we should accept your solution. Be sure to adhere to our [contribution guidelines](https://github.com/LastTalon/Vigilant/blob/master/CONTRIBUTING.md) and tag your pull request appropriately.
 
 ## Related issues
 Explain how this pull request relates to any relevant [issues](https://github.com/LastTalon/Vigilant/issues). Bugs and features should always have related issues.


### PR DESCRIPTION
## Proposed changes
Move from `.github/PULL_REQUEST_TEMPLATE/pull_request_template.md` to `.github/PULL_REQUEST_TEMPLATE.md`. Multiple pull request templates must be individually linked to and will not be used automatically.

## Related issues
Fixes #7.