### PR TITLE
Fix CI Roblox Testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: OrbitalOwen/roblox-win-installer
-        ref: "0.2"
+        ref: "0.1"
         path: roblox-win-installer
         submodules: true
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,17 +61,27 @@ jobs:
       with:
         submodules: true
 
+    - name: Download Roblox Installer
+      uses: actions/checkout@v2
+      with:
+        repository: LastTalon/roblox-win-installer
+        ref: "fix-login"
+        path: roblox-win-installer
+        submodules: true
+
     - name: Install Foreman
       uses: Roblox/setup-foreman@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Install Python Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r roblox-win-installer/requirements.txt
+
     - name: Install Roblox
       run: |
-        Invoke-WebRequest -Uri "https://github.com/OrbitalOwen/roblox-win-installer/archive/0.2.zip" -OutFile roblox-win-installer.zip
-        Expand-Archive -LiteralPath roblox-win-installer.zip -DestinationPath .
-        cd roblox-win-installer-0.2
-        pip install -r requirements.txt
+        cd roblox-win-installer
         if ([string]::IsNullOrEmpty($env:ROBLOSECURITY)) {
           $env:ROBLOSECURITY = "_|WARNING:-DO-NOT-SHARE-THIS.--Sharing-this-will-allow-someone-to-log-in-as-you-and-to-steal-your-ROBUX-and-items.|_A293A7DBE35F8BCF906689DECD6726E783BBE6B331AB7313109C611DE40FB6EC2477F6403C1CCB5DBD1E07164546B8D7457EAC598E0DA5D4BEC983F0A951F326D7FD7DC12CF279CEA78FBD21FCBB9354EF573C03A9ECC6DE188F12B3CA3C07B5F043F8A0E470AA9C18BAF9C5B5300763AACD2A1965FA71704B22496F0ED798EE022813A9053940F1697A67A8814E7F46180985A5292AA87E44B3AAD205C8850B00511E9DC9A3359E240D3FDA0F72310C9474AFCB3E3CAA80E5FD7B44A7B3A13EF3D5825F2CF6C0051572E27D283BBB0CBA7B1E39C820B07EBE6E1297D54D6854A07BDFC9ABB7F0725BECA782A719447F246033846374EB701C925B35B4F696BB6568A2A5B58A1BBECB01028A17133908759C9A4FE5254F6A2782AF28CEB0C567E6E51AA29B0990914AB99068A3D942217A48DF2E"
         }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,24 +61,17 @@ jobs:
       with:
         submodules: true
 
-    - name: Download Roblox Installer
-      run: |
-        Invoke-WebRequest -Uri "https://github.com/OrbitalOwen/roblox-win-installer/archive/0.2.zip" -OutFile roblox-win-installer.zip
-        Expand-Archive -LiteralPath roblox-win-installer.zip -DestinationPath .
-
     - name: Install Foreman
       uses: Roblox/setup-foreman@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Install Python Dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r roblox-win-installer-0.2/requirements.txt
-
     - name: Install Roblox
       run: |
+        Invoke-WebRequest -Uri "https://github.com/OrbitalOwen/roblox-win-installer/archive/0.2.zip" -OutFile roblox-win-installer.zip
+        Expand-Archive -LiteralPath roblox-win-installer.zip -DestinationPath .
         cd roblox-win-installer-0.2
+        pip install -r requirements.txt
         if ([string]::IsNullOrEmpty($env:ROBLOSECURITY)) {
           $env:ROBLOSECURITY = "_|WARNING:-DO-NOT-SHARE-THIS.--Sharing-this-will-allow-someone-to-log-in-as-you-and-to-steal-your-ROBUX-and-items.|_A293A7DBE35F8BCF906689DECD6726E783BBE6B331AB7313109C611DE40FB6EC2477F6403C1CCB5DBD1E07164546B8D7457EAC598E0DA5D4BEC983F0A951F326D7FD7DC12CF279CEA78FBD21FCBB9354EF573C03A9ECC6DE188F12B3CA3C07B5F043F8A0E470AA9C18BAF9C5B5300763AACD2A1965FA71704B22496F0ED798EE022813A9053940F1697A67A8814E7F46180985A5292AA87E44B3AAD205C8850B00511E9DC9A3359E240D3FDA0F72310C9474AFCB3E3CAA80E5FD7B44A7B3A13EF3D5825F2CF6C0051572E27D283BBB0CBA7B1E39C820B07EBE6E1297D54D6854A07BDFC9ABB7F0725BECA782A719447F246033846374EB701C925B35B4F696BB6568A2A5B58A1BBECB01028A17133908759C9A4FE5254F6A2782AF28CEB0C567E6E51AA29B0990914AB99068A3D942217A48DF2E"
         }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
     - master
-    - develop
 
 jobs:
   lemur:
@@ -66,6 +65,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: OrbitalOwen/roblox-win-installer
+        ref: "0.2"
         path: roblox-win-installer
         submodules: true
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,12 +62,9 @@ jobs:
         submodules: true
 
     - name: Download Roblox Installer
-      uses: actions/checkout@v2
-      with:
-        repository: OrbitalOwen/roblox-win-installer
-        ref: "0.1"
-        path: roblox-win-installer
-        submodules: true
+      run: |
+        Invoke-WebRequest -Uri "https://github.com/OrbitalOwen/roblox-win-installer/archive/0.2.zip" -OutFile roblox-win-installer.zip
+        Expand-Archive -LiteralPath roblox-win-installer.zip -DestinationPath .
 
     - name: Install Foreman
       uses: Roblox/setup-foreman@v1
@@ -77,11 +74,11 @@ jobs:
     - name: Install Python Dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r roblox-win-installer/requirements.txt
+        pip install -r roblox-win-installer-0.2/requirements.txt
 
     - name: Install Roblox
       run: |
-        cd roblox-win-installer
+        cd roblox-win-installer-0.2
         if ([string]::IsNullOrEmpty($env:ROBLOSECURITY)) {
           $env:ROBLOSECURITY = "_|WARNING:-DO-NOT-SHARE-THIS.--Sharing-this-will-allow-someone-to-log-in-as-you-and-to-steal-your-ROBUX-and-items.|_A293A7DBE35F8BCF906689DECD6726E783BBE6B331AB7313109C611DE40FB6EC2477F6403C1CCB5DBD1E07164546B8D7457EAC598E0DA5D4BEC983F0A951F326D7FD7DC12CF279CEA78FBD21FCBB9354EF573C03A9ECC6DE188F12B3CA3C07B5F043F8A0E470AA9C18BAF9C5B5300763AACD2A1965FA71704B22496F0ED798EE022813A9053940F1697A67A8814E7F46180985A5292AA87E44B3AAD205C8850B00511E9DC9A3359E240D3FDA0F72310C9474AFCB3E3CAA80E5FD7B44A7B3A13EF3D5825F2CF6C0051572E27D283BBB0CBA7B1E39C820B07EBE6E1297D54D6854A07BDFC9ABB7F0725BECA782A719447F246033846374EB701C925B35B4F696BB6568A2A5B58A1BBECB01028A17133908759C9A4FE5254F6A2782AF28CEB0C567E6E51AA29B0990914AB99068A3D942217A48DF2E"
         }


### PR DESCRIPTION
## Proposed changes
Fix the CI workflow's Roblox job by installing Roblox with a current stable version of roblox-win-installer.

## Related issues
This should fix #13.

